### PR TITLE
Change helm to match standard naming and neg annotation

### DIFF
--- a/cicd.yaml
+++ b/cicd.yaml
@@ -1,2 +1,2 @@
 cicd:
-  version: v0.1.125
+  version: v0.1.143

--- a/helm/testnet-faucet/Chart.yaml
+++ b/helm/testnet-faucet/Chart.yaml
@@ -1,9 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: testnet-faucet
 name: testnet-faucet
 version: 0.0.1
-dependencies:
-  - name: xpringnginx
-    version: 0.1.0-feature-XPE874-2
-    repository: oci://us-central1-docker.pkg.dev/cbdc-helm-repo/ripplex-helm-charts
-    alias: faucetng

--- a/helm/testnet-faucet/templates/faucet.yaml
+++ b/helm/testnet-faucet/templates/faucet.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $fullAppName }}-faucet-secret
+  name: {{ $fullAppName }}-secret
 type: Opaque
 data:
   NODE_ENV: {{ .Values.faucet.nodeEnv | b64enc }}
@@ -16,39 +16,41 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullAppName }}-faucet
+  name: {{ $fullAppName }}
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"443":{"name": "{{ $fullAppName }}-neg"}}}'
 spec:
   type: ClusterIP
   selector:
-    app: {{ $fullAppName }}-faucet
+    app: {{ $fullAppName }}
   ports:
   - protocol: TCP
-    port: {{ .Values.faucet.port }}
+    port: 443
     targetPort: {{ .Values.faucet.port }}
     name: public
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $fullAppName }}-faucet
+  name: {{ $fullAppName }}
 spec:
   replicas: {{ .Values.faucet.replicas }}
   selector:
     matchLabels:
-      app: {{ $fullAppName }}-faucet
+      app: {{ $fullAppName }}
   template:
     metadata:
       annotations:
         date: {{ now }}
       labels:
-        app: {{ $fullAppName }}-faucet
+        app: {{ $fullAppName }}
     spec:
       containers:
       - image: {{ .Values.faucet.image }}
-        name: {{ $fullAppName }}-faucet
+        name: {{ $fullAppName }}
         envFrom:
         - secretRef:
-            name: {{ $fullAppName }}-faucet-secret
+            name: {{ $fullAppName }}-secret
         imagePullPolicy: Always
         ports:
         - containerPort: {{ .Values.faucet.port }}

--- a/helm/testnet-faucet/values.yaml
+++ b/helm/testnet-faucet/values.yaml
@@ -7,8 +7,3 @@ faucet:
   fundingAddr: null
   fundingSecret: null
   xrpAmount: 1000
-faucetng:
-  install: true
-  releaseImage: gcr.io/xpring-dev-sandbox/xpring_nginx:0.0.3
-  fullNameOverride: faucetng-sslnginx
-  replicaCount: 1


### PR DESCRIPTION
$fullAppName contain the appname+env to match the [neg annotation](https://github.com/xpring-eng/ripplex-infra-tg/blob/908d0daaf1d34886baf2872e9cffcaaf724fecf4/environments/dev-sandbox/gcp-https-lb%3Atestnet-faucet/components.tfvars#L7)
