### PR TITLE
add seed in response object

### DIFF
--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { getConnectedClient, resetClient } from "../client";
 import { getDestinationAccount } from "../destination-wallet";
 import { Client, Payment, Wallet, xrpToDrops } from "xrpl";
-import { Account, ResponseType } from "../types";
+import { Account, FundedResponse } from "../types";
 import { fundingWallet } from "../wallet";
 import { BigQuery } from "@google-cloud/bigquery";
 import { config } from "../config";
@@ -85,7 +85,7 @@ export default async function (req: Request, res: Response) {
 
     const status = result.engine_result;
 
-    const response: ResponseType = {
+    const response: FundedResponse = {
       account: account,
       amount: amount,
     };

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -87,7 +87,7 @@ export default async function (req: Request, res: Response) {
 
     const response: FundedResponse = {
       account: account,
-      amount: amount,
+      amount: Number(amount),
     };
 
     if (wallet.seed) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
 export interface Account {
-  xAddress: string,
-  classicAddress: string,
-  address: string,
-  tag?: number | boolean
+  xAddress: string;
+  classicAddress: string;
+  address: string;
+  tag?: number | boolean;
+}
+export interface ResponseType {
+  account: Account;
+  amount: string;
+  seed?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface Account {
   address: string;
   tag?: number | boolean;
 }
-export interface ResponseType {
+export interface FundedResponse {
   account: Account;
   amount: string;
   seed?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,6 @@ export interface Account {
 }
 export interface FundedResponse {
   account: Account;
-  amount: string;
+  amount: number;
   seed?: string;
 }


### PR DESCRIPTION
add wallet seed back in successful response objects (if the user didn't provide a funding destination address)
