### PR TITLE
fix faucet error due to adding seed 

### DIFF
--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -90,7 +90,7 @@ export default async function (req: Request, res: Response) {
       amount: Number(amount),
     };
 
-    if (wallet.seed) {
+    if (wallet && wallet.seed) {
       response.seed = wallet.seed;
     }
 


### PR DESCRIPTION
fix faucet error (when supplying a destination) due to adding seed back to the response object 
