### PR TITLE
Caspian Migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+
+# production or development
+NODE_ENV="production" 
+# local port the faucet will be hosted on
+PORT=3000
+# testnet websocket address - Fill in other test networks url if needed 
+RIPPLED_URI="wss://s.altnet.rippletest.net:51233" 
+# funding address & secret, using genesis account is not recommended, please prefund your faucet account
+FUNDING_ADDRESS=
+FUNDING_SECRET=
+# default faucet funding amount
+XRP_AMOUNT= 1000
+
+# Big Query credentials
+BIGQUERY_PRIVATE_KEY=""
+BIGQUERY_CLIENT_EMAIL=""
+BIGQUERY_PROJECT_ID=""
+BIGQUERY_DATASET_ID = ""
+BIGQUERY_TABLE_ID = ""
+
+# Caspian credentials
+CASPIAN_ENDPOINT=""
+CASPIAN_API_KEY=""
+CASPIAN_PRODUCER_NAME=""
+CASPIAN_ENTITY_NAME=""
+CASPIAN_SCHEMA_TYPE=""
+CASPIAN_SCHEMA_VERSION=
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,28 @@ Please replace `CASPIAN_ENDPOINT`, `CASPIAN_API_KEY`, `CASPIAN_PRODUCER_NAME`, `
 `CASPIAN_SCHEMA_VERSION`: The version of your data schema.
 Remember to properly secure your environment variables, especially the CASPIAN_API_KEY, to prevent unauthorized access to your Caspian account.
 
+## Google BigQuery Integration
+
+This application logs and analyzes data using Google BigQuery. To use this feature, you need to provide the necessary BigQuery credentials through environment variables.
+
+### Run the server with BigQuery (Optional):
+
+Please replace `BIGQUERY_PROJECT_ID`, `BIGQUERY_CLIENT_EMAIL`, and `BIGQUERY_PRIVATE_KEY` with your actual project ID, client email, and private key.
+
+### BigQuery Environment Variables:
+
+- `BIGQUERY_PROJECT_ID`: The ID of your Google Cloud project.
+- `BIGQUERY_CLIENT_EMAIL`: The email address of your service account.
+- `BIGQUERY_PRIVATE_KEY`: The private key from your service account JSON key file. Be sure to include the full private key, including the header and footer.
+
+In case you are running this application in a trusted environment (like Google Cloud Platform), you don't need to provide the `BIGQUERY_CLIENT_EMAIL` and `BIGQUERY_PRIVATE_KEY`. The application will use Application Default Credentials (ADC) provided by the environment.
+
+```
+
+Please adjust the details as per your application requirements.
+
+```
+
 ### how to run tests on Standalone Node
 
 1. Creating a custom standalone rippled instance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ You should now have a running docker container with your custom config!
 
 (If you were trying the network_id change, you should see it show up in the docker logs on startup!)
 
-In ticket-queue.ts and account.ts, import `sendLedgerAccept` and `delayedLedgerAccept()` from utils.ts
+2. In ticket-queue.ts and account.ts, import `sendLedgerAccept` and `delayedLedgerAccept()` from utils.ts
 
 ```
 async function sendLedgerAccept(client: Client): Promise<unknown> {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ Environment variables:
 
 - `XRP_AMOUNT`: The number of XRP to fund new accounts with. On the Testnet operated by Ripple, the current funding amount is 1,000 Testnet XRP.
 
+# Logging
+
+This application support both Caspian and BigQuery recording/loggings, see below for intructions.
+
 ## Caspian Integration
 
 This application logs and analyzes data using Caspian. To use this feature, you need to provide the necessary Caspian credentials through environment variables.
@@ -74,32 +78,34 @@ Please adjust the details as per your application requirements.
 
 1. Creating a custom standalone rippled instance
 
-Create a folder called config
+   1. Create a folder called `config`
 
-Create a config file like xrpl.js uses in it’s CI for making standalone rippled instances: https://github.com/XRPLF/xrpl.js/blob/main/.ci-config/rippled.cfg
+   2. Create a config file like xrpl.js uses in it’s CI for making standalone rippled instances: https://github.com/XRPLF/xrpl.js/blob/main/.ci-config/rippled.cfg
 
-If you want to change something, like increase the network_id, you can search the example config for the field name, then add it anywhere. For example:
+   If you want to change something, like increase the network_id, you can search the example config for the field name, then add it anywhere. For example:
 
-[network_id]
-1234
+   [network_id]
+   1234
 
-Go to right above config in the command line
+   3. Go to right above `config` in the command line
+   4. Use the `config `folder to start a docker container using a command like in xrpl.js tests. Source for command pre-modification + explanation of each piece.
 
-Use the config folder to start a docker container using a command like in xrpl.js tests. Source for command pre-modification + explanation of each piece.
+   Modifications:
 
-Modifications:
+   Changed the path to the `config` folder from `$PWD/.ci-config` to `$PWD/config:/config/`
 
-Changed the path to the config folder from $PWD/.ci-config to $PWD/config:/config/
+   NOTE: This is pointing to a FOLDER not a file!
 
-NOTE: This is pointing to a FOLDER not a file!
+   Also updated the xrpllabsofficial version to be it’s generic form instead of specifically the beta (which is currently in use for xrpl.js)
 
-Also updated the xrpllabsofficial version to be it’s generic form instead of specifically the beta (which is currently in use for xrpl.js)
+   ```
+   docker run -p 6006:6006 --interactive -t --volume $PWD/config:/config/ xrpllabsofficial -a --start
 
-docker run -p 6006:6006 --interactive -t --volume $PWD/config:/config/ xrpllabsofficial -a --start
+   ```
 
-You should now have a running docker container with your custom config!
+   You should now have a running docker container with your custom config!
 
-(If you were trying the network_id change, you should see it show up in the docker logs on startup!)
+   (If you were trying the network_id change, you should see it show up in the docker logs on startup!)
 
 2. In ticket-queue.ts and account.ts, import `sendLedgerAccept` and `delayedLedgerAccept()` from utils.ts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,42 +30,36 @@ Environment variables:
 
 - `XRP_AMOUNT`: The number of XRP to fund new accounts with. On the Testnet operated by Ripple, the current funding amount is 1,000 Testnet XRP.
 
-## Google BigQuery Integration
+## Caspian Integration
 
-This application logs and analyzes data using Google BigQuery. To use this feature, you need to provide the necessary BigQuery credentials through environment variables.
+This application logs and analyzes data using Caspian. To use this feature, you need to provide the necessary Caspian credentials through environment variables.
 
-### Run the server with BigQuery (Optional):
+### Run the server with Caspian (Optional):
 
-Please replace `BIGQUERY_PROJECT_ID`, `BIGQUERY_CLIENT_EMAIL`, and `BIGQUERY_PRIVATE_KEY` with your actual project ID, client email, and private key.
+Please replace `CASPIAN_ENDPOINT`, `CASPIAN_API_KEY`, `CASPIAN_PRODUCER_NAME`, `CASPIAN_ENTITY_NAME`, `CASPIAN_SCHEMA_TYPE`, and `CASPIAN_SCHEMA_VERSION `with your actual Caspian configurations.
 
-### BigQuery Environment Variables:
+### Caspian Environment Variables:
 
-- `BIGQUERY_PROJECT_ID`: The ID of your Google Cloud project.
-- `BIGQUERY_CLIENT_EMAIL`: The email address of your service account.
-- `BIGQUERY_PRIVATE_KEY`: The private key from your service account JSON key file. Be sure to include the full private key, including the header and footer.
+`CASPIAN_ENDPOINT`: The endpoint for your Caspian integration.
+`CASPIAN_API_KEY`: Your Caspian API key for authentication.
+`CASPIAN_PRODUCER_NAME`: The name of your data producer.
+`CASPIAN_ENTITY_NAME`: The entity name for logging purposes.
+`CASPIAN_SCHEMA_TYPE`: The schema type of your data.
+`CASPIAN_SCHEMA_VERSION`: The version of your data schema.
+Remember to properly secure your environment variables, especially the CASPIAN_API_KEY, to prevent unauthorized access to your Caspian account.
 
-In case you are running this application in a trusted environment (like Google Cloud Platform), you don't need to provide the `BIGQUERY_CLIENT_EMAIL` and `BIGQUERY_PRIVATE_KEY`. The application will use Application Default Credentials (ADC) provided by the environment.
+### how to run tests on Standalone Node
 
-```
-
-Please adjust the details as per your application requirements.
-
-
-```
-
-
-### how to run tests on Standalone Node 
 1. Creating a custom standalone rippled instance
 
 Create a folder called config
 
-Create a config file like xrpl.js uses in it’s CI for making standalone rippled instances: https://github.com/XRPLF/xrpl.js/blob/main/.ci-config/rippled.cfg 
+Create a config file like xrpl.js uses in it’s CI for making standalone rippled instances: https://github.com/XRPLF/xrpl.js/blob/main/.ci-config/rippled.cfg
 
-If you want to change something, like increase the network_id, you can search the example config  for the field name, then add it anywhere. For example:
+If you want to change something, like increase the network_id, you can search the example config for the field name, then add it anywhere. For example:
 
 [network_id]
 1234
-
 
 Go to right above config in the command line
 
@@ -85,8 +79,8 @@ You should now have a running docker container with your custom config!
 
 (If you were trying the network_id change, you should see it show up in the docker logs on startup!)
 
+In ticket-queue.ts and account.ts, import `sendLedgerAccept` and `delayedLedgerAccept()` from utils.ts
 
-In ticket-queue.ts and account.ts, import  `sendLedgerAccept` and `delayedLedgerAccept()` from utils.ts
 ```
 async function sendLedgerAccept(client: Client): Promise<unknown> {
   return client.connection.request({ command: "ledger_accept" });
@@ -99,4 +93,5 @@ async function delayedLedgerAccept(): Promise<unknown> {
     }
 
 ```
+
 use `delayedLedgerAccept()` before `client.submitAndWait()` and `await sendLedgerAccept()` after `client.submit()` in order to close the ledger on a standalone node.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Please adjust the details as per your application requirements.
 
 ```
 
-### how to run tests on Standalone Node
+### How to run tests on Standalone Node
 
 1. Creating a custom standalone rippled instance
 

--- a/README.md
+++ b/README.md
@@ -30,25 +30,23 @@ Environment variables:
 
 - `XRP_AMOUNT`: The number of XRP to fund new accounts with. On the Testnet operated by Ripple, the current funding amount is 1,000 Testnet XRP.
 
-## Google BigQuery Integration
+## Caspian Integration
 
-This application logs and analyzes data using Google BigQuery. To use this feature, you need to provide the necessary BigQuery credentials through environment variables.
+This application logs and analyzes data using Caspian. To use this feature, you need to provide the necessary Caspian credentials through environment variables.
 
-### Run the server with BigQuery (Optional):
+### Run the server with Caspian (Optional):
 
-Please replace `BIGQUERY_PROJECT_ID`, `BIGQUERY_CLIENT_EMAIL`, and `BIGQUERY_PRIVATE_KEY` with your actual project ID, client email, and private key.
+Please replace `CASPIAN_ENDPOINT`, `CASPIAN_API_KEY`, `CASPIAN_PRODUCER_NAME`, `CASPIAN_ENTITY_NAME`, `CASPIAN_SCHEMA_TYPE`, and `CASPIAN_SCHEMA_VERSION `with your actual Caspian configurations.
 
-### BigQuery Environment Variables:
+### Caspian Environment Variables:
 
-- `BIGQUERY_PROJECT_ID`: The ID of your Google Cloud project.
-- `BIGQUERY_CLIENT_EMAIL`: The email address of your service account.
-- `BIGQUERY_PRIVATE_KEY`: The private key from your service account JSON key file. Be sure to include the full private key, including the header and footer.
-
-In case you are running this application in a trusted environment (like Google Cloud Platform), you don't need to provide the `BIGQUERY_CLIENT_EMAIL` and `BIGQUERY_PRIVATE_KEY`. The application will use Application Default Credentials (ADC) provided by the environment.
+`CASPIAN_ENDPOINT`: The endpoint for your Caspian integration.
+`CASPIAN_API_KEY`: Your Caspian API key for authentication.
+`CASPIAN_PRODUCER_NAME`: The name of your data producer.
+`CASPIAN_ENTITY_NAME`: The entity name for logging purposes.
+`CASPIAN_SCHEMA_TYPE`: The schema type of your data.
+`CASPIAN_SCHEMA_VERSION`: The version of your data schema.
 
 ```
-
-Please adjust the details as per your application requirements.
-
-
+Remember to properly secure your environment variables, especially the CASPIAN_API_KEY, to prevent unauthorized access to your Caspian account.
 ```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ Please replace `CASPIAN_ENDPOINT`, `CASPIAN_API_KEY`, `CASPIAN_PRODUCER_NAME`, `
 ```
 Remember to properly secure your environment variables, especially the CASPIAN_API_KEY, to prevent unauthorized access to your Caspian account.
 ```
+
+## Google BigQuery Integration
+
+This application logs and analyzes data using Google BigQuery. To use this feature, you need to provide the necessary BigQuery credentials through environment variables.
+
+### Run the server with BigQuery (Optional):
+
+Please replace `BIGQUERY_PROJECT_ID`, `BIGQUERY_CLIENT_EMAIL`, and `BIGQUERY_PRIVATE_KEY` with your actual project ID, client email, and private key.
+
+### BigQuery Environment Variables:
+
+- `BIGQUERY_PROJECT_ID`: The ID of your Google Cloud project.
+- `BIGQUERY_CLIENT_EMAIL`: The email address of your service account.
+- `BIGQUERY_PRIVATE_KEY`: The private key from your service account JSON key file. Be sure to include the full private key, including the header and footer.
+
+In case you are running this application in a trusted environment (like Google Cloud Platform), you don't need to provide the `BIGQUERY_CLIENT_EMAIL` and `BIGQUERY_PRIVATE_KEY`. The application will use Application Default Credentials (ADC) provided by the environment.
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,15 @@ export interface ConfigFile {
   BIGQUERY_CLIENT_EMAIL?: string;
   BIGQUERY_PROJECT_ID?: string;
   BIGQUERY_PRIVATE_KEY?: string;
+  
+
+  // 
+  CASPIAN_ENDPOINT?: string;
+  CASPIAN_API_KEY?: string;
+  CASPIAN_PRODUCER_NAME?: string;
+  CASPIAN_ENTITY_NAME?: string;
+  CASPIAN_SCHEMA_TYPE?: string;
+  CASPIAN_SCHEMA_VERSION?: number;
 }
 
 export interface Config extends Required<ConfigFile> {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,19 +11,10 @@ export interface ConfigFile {
   MIN_TICKET_COUNT?: number;
   MAX_TICKET_COUNT?: number;
 
-  // Optional - See "defaults" for default values
-  BIGQUERY_DATASET_ID?: string;
-  BIGQUERY_TABLE_ID?: string;
-  BIGQUERY_CLIENT_EMAIL?: string;
-  BIGQUERY_PROJECT_ID?: string;
-  BIGQUERY_PRIVATE_KEY?: string;
-  
-
-  // 
-  CASPIAN_ENDPOINT?: string;
   CASPIAN_API_KEY?: string;
-  CASPIAN_PRODUCER_NAME?: string;
+  CASPIAN_ENDPOINT?: string;
   CASPIAN_ENTITY_NAME?: string;
+  CASPIAN_PRODUCER_NAME?: string;
   CASPIAN_SCHEMA_TYPE?: string;
   CASPIAN_SCHEMA_VERSION?: number;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,13 @@ export interface ConfigFile {
   MIN_TICKET_COUNT?: number;
   MAX_TICKET_COUNT?: number;
 
+  // Optional - See "defaults" for default values
+  BIGQUERY_DATASET_ID?: string;
+  BIGQUERY_TABLE_ID?: string;
+  BIGQUERY_CLIENT_EMAIL?: string;
+  BIGQUERY_PROJECT_ID?: string;
+  BIGQUERY_PRIVATE_KEY?: string;
+
   CASPIAN_API_KEY?: string;
   CASPIAN_ENDPOINT?: string;
   CASPIAN_ENTITY_NAME?: string;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,104 @@
+import { Account } from "./types";
+import { BigQuery } from "@google-cloud/bigquery";
+import { config } from "./config";
+
+export async function insertIntoCaspian(
+  account: Account,
+  amount: number,
+  reqBody: any,
+  networkId: number
+): Promise<any> {
+  const dataPayload = [
+    {
+      user_agent: reqBody.userAgent || "",
+      usage_context: reqBody.usageContext || "",
+      memos: reqBody.memos || [],
+      account: account.xAddress,
+      amount: amount,
+      network: networkId,
+    },
+  ];
+
+  const postData = JSON.stringify({
+    producerName: config.CASPIAN_PRODUCER_NAME,
+    entityName: config.CASPIAN_ENTITY_NAME,
+    schemaType: config.CASPIAN_SCHEMA_TYPE,
+    schemaVersion: Math.round(config.CASPIAN_SCHEMA_VERSION),
+    data: dataPayload,
+    timestamp: Date.now(),
+  });
+
+  try {
+    const response = await fetch(config.CASPIAN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": config.CASPIAN_API_KEY,
+      },
+      body: postData,
+    });
+
+    if (response.ok) {
+      return await response.json();
+    } else {
+      const errorMessage = await response.text();
+      throw new Error(`Failed to send data to Caspian: ${errorMessage}`);
+    }
+  } catch (error) {
+    console.error("Request Error:", error);
+    throw {
+      message: `Failed to send data to Caspian: ${
+        error.message || "Unknown error"
+      }`,
+      attemptedData: postData,
+    };
+  }
+}
+
+// not in use currently
+export async function insertIntoBigQuery(
+  account: Account,
+  amount: string,
+  reqBody: any,
+  networkID: number
+): Promise<void> {
+  const { userAgent = "", usageContext = "" } = reqBody;
+  const memos = reqBody.memos
+    ? reqBody.memos.map((memo: any) => ({ memo }))
+    : [];
+  const rows = [
+    {
+      user_agent: userAgent,
+      usage_context: usageContext,
+      memos: memos,
+      account: account.xAddress,
+      amount: amount,
+      networkID,
+    },
+  ];
+  const bigquery = new BigQuery({
+    projectId: config.BIGQUERY_PROJECT_ID,
+    credentials: {
+      client_email: config.BIGQUERY_CLIENT_EMAIL,
+      private_key: config.BIGQUERY_PRIVATE_KEY,
+    },
+  });
+
+  return new Promise((resolve, reject) => {
+    bigquery
+      .dataset(config.BIGQUERY_DATASET_ID)
+      .table(config.BIGQUERY_TABLE_ID)
+      .insert(rows, (error) => {
+        if (error) {
+          console.warn(
+            "WARNING: Failed to insert into BigQuery",
+            JSON.stringify(error, null, 2)
+          );
+          reject(error);
+        } else {
+          console.log(`Inserted ${rows.length} rows`);
+          resolve();
+        }
+      });
+  });
+}

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,6 +2,7 @@ import { Account } from "./types";
 import { BigQuery } from "@google-cloud/bigquery";
 import { config } from "./config";
 
+///Depending on your setup, you can use either Caspian or BigQuery for logging. Other databases may be added in the future
 export async function insertIntoCaspian(
   account: Account,
   amount: number,
@@ -55,12 +56,10 @@ export async function insertIntoCaspian(
   }
 }
 
-// not in use currently
 export async function insertIntoBigQuery(
   account: Account,
   amount: string,
-  reqBody: any,
-  networkID: number
+  reqBody: any
 ): Promise<void> {
   const { userAgent = "", usageContext = "" } = reqBody;
   const memos = reqBody.memos
@@ -73,7 +72,6 @@ export async function insertIntoBigQuery(
       memos: memos,
       account: account.xAddress,
       amount: amount,
-      networkID,
     },
   ];
   const bigquery = new BigQuery({

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,7 +2,7 @@ import { Account } from "./types";
 import { BigQuery } from "@google-cloud/bigquery";
 import { config } from "./config";
 
-///Depending on your setup, you can use either Caspian or BigQuery for logging. Other databases may be added in the future
+// Depending on your setup, you can use either Caspian or BigQuery for logging. Other databases may be added in the future
 export async function insertIntoCaspian(
   account: Account,
   amount: number,

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -43,7 +43,7 @@ export async function insertIntoCaspian(
       return await response.json();
     } else {
       const errorMessage = await response.text();
-      throw new Error(`Failed to send data to Caspian: ${errorMessage}`);
+      throw new Error(`${errorMessage}`);
     }
   } catch (error) {
     console.error("Request Error:", error);

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -210,7 +210,7 @@ async function insertIntoCaspian(
         message: `Failed to send data to Caspian: ${
           error.message || "Unknown error"
         }`,
-        attemptedData: postData, // Here, we include the data that was being sent
+        attemptedData: postData,
       });
     });
 

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -8,7 +8,7 @@ import { config } from "../config";
 import { getTicket } from "../ticket-queue";
 import rTracer from "cls-rtracer";
 import { incrementTxRequestCount, incrementTxCount } from "../index";
-import { insertIntoCaspian } from "../logging";
+import { insertIntoCaspian, insertIntoBigQuery } from "../logging";
 
 export default async function (req: Request, res: Response) {
   incrementTxRequestCount();
@@ -114,6 +114,15 @@ export default async function (req: Request, res: Response) {
           console.warn("Caspian Insertion Error:", error);
         }
       }
+      if (config.BIGQUERY_PROJECT_ID) {
+        try {
+          await insertIntoBigQuery(account, amount, req.body);
+          console.log("inserted big query");
+        } catch (error) {
+          console.warn(`Failed to insert into BigQuery: ${error}`);
+        }
+      }
+
       incrementTxCount();
       res.send(response);
     }


### PR DESCRIPTION
use Caspian API to ingest data instead of BigQuery, and add network ID as a field for usage tracking beyond testnet 