### PR TITLE
Remove dependency on `requestAll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,25 @@ Funds new Testnet accounts
 
 ### Run the server:
 
+1. Add / update `.env` with the following values:
+
+```
+NODE_ENV="production"
+PORT=3000
+RIPPLED_URI="wss://s.altnet.rippletest.net:51233"
+FUNDING_ADDRESS=<address>
+FUNDING_SECRET=<secret>
+XRP_AMOUNT=10000
+```
+
+- For testing, create an account on testnet or use an existing one by updating `FUNDING_ADDRESS` and `FUNDING_SECRET`
+- For production testnet faucet, use the account with the address `rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe` and it's corresponding secret
+- Production environments should also configure either the BigQuery or Caspian environment variables as specified below
+
+2. Run the following commands:
+
 ```
 npm install
-NODE_ENV="production" PORT=3000 RIPPLED_URI="wss://s.altnet.rippletest.net:51233" FUNDING_ADDRESS=rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe FUNDING_SECRET=<secret> XRP_AMOUNT=10000
 npm start
 ```
 
@@ -66,4 +82,3 @@ Please replace `BIGQUERY_PROJECT_ID`, `BIGQUERY_CLIENT_EMAIL`, and `BIGQUERY_PRI
 - `BIGQUERY_PRIVATE_KEY`: The private key from your service account JSON key file. Be sure to include the full private key, including the header and footer.
 
 In case you are running this application in a trusted environment (like Google Cloud Platform), you don't need to provide the `BIGQUERY_CLIENT_EMAIL` and `BIGQUERY_PRIVATE_KEY`. The application will use Application Default Credentials (ADC) provided by the environment.
-

--- a/src/ticket-queue.ts
+++ b/src/ticket-queue.ts
@@ -18,7 +18,7 @@ let createTicketsPromise: Promise<void | TxResponse<TicketCreate>> = null;
 export async function populateTicketQueue(client: Client) {
   // Get account info
   let marker = undefined;
-  const responses: AccountObjectsResponse[] = []
+  const responses: AccountObjectsResponse[] = [];
   do {
     const response: AccountObjectsResponse = await client.request({
       command: "account_objects",
@@ -27,10 +27,10 @@ export async function populateTicketQueue(client: Client) {
       limit: 300,
       marker,
     });
-    responses.push(response)
+    responses.push(response);
     marker = response.result.marker;
-  } while (Boolean(marker))
-  
+  } while (Boolean(marker));
+
   // Empty the ticket queue before refilling it
   ticketQueue = [];
 

--- a/src/ticket-queue.ts
+++ b/src/ticket-queue.ts
@@ -17,12 +17,20 @@ let createTicketsPromise: Promise<void | TxResponse<TicketCreate>> = null;
 // this will be called when client is connected
 export async function populateTicketQueue(client: Client) {
   // Get account info
-  const responses: AccountObjectsResponse[] = await client.requestAll({
-    command: "account_objects",
-    account: fundingWallet.address,
-    type: "ticket",
-    limit: 300,
-  });
+  let marker = undefined;
+  const responses: AccountObjectsResponse[] = []
+  do {
+    const response: AccountObjectsResponse = await client.request({
+      command: "account_objects",
+      account: fundingWallet.address,
+      type: "ticket",
+      limit: 300,
+      marker,
+    });
+    responses.push(response)
+    marker = response.result.marker;
+  } while (Boolean(marker))
+  
   // Empty the ticket queue before refilling it
   ticketQueue = [];
 


### PR DESCRIPTION
## High Level Overview of Change

Faucet was unable to get tickets due to `requestAll` always returning 0 tickets even when the faucet account had tickets.

### Context of Change

There was a bug where the testnet faucet couldn't tell how many tickets it had because `Client.requestAll` was not working properly. This will be fixed in a future version of xrpl.js, but for now we're removing that dependency in the faucet.

Also updated the README's testing steps.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Updates

## Test Plan

* Manually verified that the testnet faucet could accurately count how many tickets were in the testnet faucet account (before fix -> 0, after fix -> 219)
* Also verified that it still could make accounts + refill tickets in a "normal" situation (account with not that many objects)

<!--
## Future Tasks
For future tasks related to PR.
-->
